### PR TITLE
Build project with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,11 @@ With conda
 
 1. Create a conda environment from the *environment.yml* file and activate it
 2. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
-3. Build/install this project with ``make install``
+3. Build/install this project with:
+
+   .. code-block:: bash
+
+    $ make install
 
 With pip
 ........
@@ -33,7 +37,11 @@ Make, CMake, and a Fortran compiler are required.
 
     $ pip install meson-python meson ninja cython numpy bmipy
 
-5. Build/install this project with ``make install``
+5. Build/install this project with:
+
+   .. code-block:: bash
+
+    $ make install
 
 Use
 ---

--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,35 @@ pymt_heatf
 This is an example of building a model,
 written in Fortran and wrapped in Python with the `babelizer <https://github.com/csdms/babelizer>`_,
 with the `meson-python <https://meson-python.readthedocs.io/en/latest/>`_ build system
-using a ``pyproject.toml`` file to describe the build.
+using a *pyproject.toml* file to describe the build.
 
 Build/Install
 -------------
 
 This is a sketch of how to build and install this project.
 
-1. Create the conda environment from `environment.yml` and activate it
+With conda
+..........
+
+1. Create a conda environment from the *environment.yml* file and activate it
 2. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
 3. Build/install this project with ``make install``
+
+With pip
+........
+
+Make, CMake, and a Fortran compiler are required.
+
+1. Create a virtual environment
+2. Build/install the `Fortran BMI specification <https://github.com/csdms/bmi-fortran/#buildinstall>`_ (it's not installable through ``pip``)
+3. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
+4. Install the build system requirements through ``pip``:
+
+   .. code-block:: bash
+
+    $ pip install meson-python meson ninja cython numpy bmipy
+
+5. Build/install this project with ``make install``
 
 Use
 ---

--- a/README.rst
+++ b/README.rst
@@ -5,19 +5,19 @@ pymt_heatf
 This is an example of building a model,
 written in Fortran and wrapped in Python with the `babelizer <https://github.com/csdms/babelizer>`_,
 with the `meson-python <https://meson-python.readthedocs.io/en/latest/>`_ build system
-using a *pyproject.toml* file to describe the build.
+using only a *pyproject.toml* file for project metadata.
 
 Build/Install
 -------------
 
-This is a sketch of how to build and install this project.
+This is a sketch of how to build and install this project with either ``conda`` or ``pip``.
 
 With conda
 ..........
 
-1. Create a conda environment from the *environment.yml* file and activate it
+1. Create a conda environment from the included *environment.yml* file and activate it
 2. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
-3. Build/install this project with:
+3. Build/install the project with:
 
    .. code-block:: bash
 
@@ -29,15 +29,15 @@ With pip
 Make, CMake, and a Fortran compiler are required.
 
 1. Create a virtual environment
-2. Build/install the `Fortran BMI specification <https://github.com/csdms/bmi-fortran/#buildinstall>`_ (it's not installable through ``pip``)
-3. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
-4. Install the build system requirements through ``pip``:
+2. Install the build system requirements through ``pip``:
 
    .. code-block:: bash
 
     $ pip install meson-python meson ninja cython numpy bmipy
 
-5. Build/install this project with:
+3. Build/install the `Fortran BMI specification <https://github.com/csdms/bmi-fortran/#buildinstall>`_ (it's not installable through ``pip``)
+4. Build/install the `Fortran BMI example <https://github.com/csdms/bmi-example-fortran/#buildinstall>`_
+5. Build/install the project with:
 
    .. code-block:: bash
 
@@ -58,4 +58,4 @@ Import the *pymt* component:
 
     >>> from pymt.MODELS import HeatModelF
 
-Try the examples in the `examples` directory.
+Try the examples in the *examples* directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "meson",
+  "meson-python",
+  "ninja",
+  "cython",
+  "make",
+]
+lint = [
   "black",
   "ruff",
   "isort",


### PR DESCRIPTION
This PR includes instructions on how to build and install this project solely through `pip`. This fixes #8.