### PR TITLE
Set up a monthly build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '17 4 3 * *'  # 4:17a on third day of the month
 
 env:
   BUILD_DIR: _build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '17 4 3 * *'  # 4:17a on third day of the month
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   BUILD_DIR: _build
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,7 @@
 
 ## 3.3 (unreleased)
 
-
-- Nothing changed yet.
-
+- Set up a monthly build (#13)
 
 ## 3.2 (2024-12-20)
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'pymt_heatf',
     'c', 'cython', 'fortran',
-    version: '3.2.dev0',
+    version: '3.3.dev0',
     license: 'MIT',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,6 @@
 project(
     'pymt_heatf',
     'c', 'cython', 'fortran',
-    version: '3.3.dev0',
     license: 'MIT',
 )
 


### PR DESCRIPTION
This PR adds a cron job to run the *test* workflow once per month. It also makes the *test* workflow cancelable.